### PR TITLE
occamy: SPI bringup

### DIFF
--- a/arch/riscv/dts/occamy.dts
+++ b/arch/riscv/dts/occamy.dts
@@ -78,6 +78,7 @@
       reg = <0x0 0x4c000000 0x0 0x10000>;
       xlnx,num-ss-bits = <1>;
       xlnx,num-transfer-bits = <0x8>;
+      fifo-size = <16>;
       #address-cells = <1>;
       #size-cells = <0>;
     };

--- a/drivers/spi/spi-uclass.c
+++ b/drivers/spi/spi-uclass.c
@@ -376,9 +376,7 @@ int spi_get_bus_and_cs(int busnum, int cs, int speed, int mode,
 				__func__, ret);
 			return ret;
 		}
-		dev_dbg(bus, "In here\n");
 		plat = dev_get_parent_plat(dev);
-		dev_dbg(bus, "After parent_plat\n");
 
 		plat->cs = cs;
 		if (speed) {
@@ -396,22 +394,17 @@ int spi_get_bus_and_cs(int busnum, int cs, int speed, int mode,
 		return ret;
 	}
 
-	dev_dbg(bus, "Before device active\n");
 	if (!device_active(dev)) {
 		struct spi_slave *slave;
 
-		dev_dbg(bus, "Before probe\n");
 		ret = device_probe(dev);
-		dev_dbg(bus, "After probe\n");
 		if (ret)
 			goto err;
 		slave = dev_get_parent_priv(dev);
 		slave->dev = dev;
 	}
 
-	dev_dbg(bus, "Before parent\n");
 	slave = dev_get_parent_priv(dev);
-	dev_dbg(bus, "Before uclass_priv\n");
 	bus_data = dev_get_uclass_priv(bus);
 
         /*

--- a/drivers/spi/xilinx_spi.c
+++ b/drivers/spi/xilinx_spi.c
@@ -110,7 +110,6 @@ struct xilinx_spi_priv {
 
 static int xilinx_spi_probe(struct udevice *bus)
 {
-    debug("In Xilinx Probe\n");
 	struct xilinx_spi_priv *priv = dev_get_priv(bus);
 	struct xilinx_spi_regs *regs = priv->regs;
     priv->regs = (struct xilinx_spi_regs *)dev_read_addr(bus);

--- a/drivers/timer/riscv_timer.c
+++ b/drivers/timer/riscv_timer.c
@@ -21,7 +21,9 @@ static u64 notrace riscv_timer_get_count(struct udevice *dev)
 	__maybe_unused u32 hi, lo;
 
 	if (IS_ENABLED(CONFIG_64BIT))
-		return csr_read(CSR_TIME);
+		// TODO(niwis): This gives an illegal instruction on Ariane in M-Mode.
+		// return csr_read(CSR_TIME);
+		return *(u64*)(0x400bff8);
 
 	do {
 		hi = csr_read(CSR_TIMEH);


### PR DESCRIPTION
This adds the `fifo-size` property to the Xilinx Quad-SPI in `occamy.dts`, allowing `u-boot` to access Occamy's attached Xilinx Quad-SPI flash.