### PR TITLE
occamy: Revert deactivating isolation

### DIFF
--- a/board/pulp-platform/occamy/occamy_spl.c
+++ b/board/pulp-platform/occamy/occamy_spl.c
@@ -14,10 +14,6 @@
 
 int spl_board_init_f(void)
 {
-	/* disable AXI isolation */
-	SOC_CTRL(ISOLATE_0) = 0;
-	SOC_CTRL(ISOLATE_1) = 0;
-
 	return 0;
 }
 


### PR DESCRIPTION
Do not deactivate isolation on `spl_board_init`, as this is not required by occamy anymore (https://github.com/pulp-platform/snitch/pull/213)